### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:$rootProject.fabric_loader_version"
 
     include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.5.0-beta.3")))
-    include(implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0")))
+    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0")))
     modApi("maven.modrinth:lithium:ZSNsJrPI")
 
     common(project(path: ':common', configuration: 'namedElements')) { transitive false }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:$rootProject.fabric_loader_version"
 
     include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.5.0-beta.3")))
-    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0")))
+    include(implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0")))
     modApi("maven.modrinth:lithium:ZSNsJrPI")
 
     common(project(path: ':common', configuration: 'namedElements')) { transitive false }


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_